### PR TITLE
fix: use markdown strikethrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Log4j impact manufacturers and components summary from the Internet community. W
 
 
 
-#### -Redis- (not a JAVA app)
+#### ~Redis~ (not a JAVA app)
 
 #### Elastic
 


### PR DESCRIPTION
Use markdown strikethrough to make it clear redis is not vulnerable.

Before:
![image](https://user-images.githubusercontent.com/718899/145657312-36f166c7-49ee-415a-8e17-a619c035bd9b.png)

After:
![image](https://user-images.githubusercontent.com/718899/145657339-c5476d30-ba14-4c40-87ce-fd703c7a7d1c.png)

Hmmm...guess that's not *that* much of a difference....